### PR TITLE
blobdetection.py - removed unsupported args from function call to figure.subplot_imshow

### DIFF
--- a/blobdetection.py
+++ b/blobdetection.py
@@ -376,11 +376,11 @@ class BlobDetection(cellprofiler.module.Module):
 
         figure.set_subplots((3, 1), dimensions=dimensions)
 
-        figure.subplot_imshow(0, 0, x_data, colormap=colormap, dimensions=dimensions)
+        figure.subplot_imshow(0, 0, x_data, colormap=colormap)
 
-        figure.subplot_imshow(1, 0, overlay, dimensions=dimensions)
+        figure.subplot_imshow(1, 0, overlay)
 
-        figure.subplot_imshow(2, 0, y_data, colormap=colormap, dimensions=dimensions)
+        figure.subplot_imshow(2, 0, y_data, colormap=colormap)
 
     def volumetric(self):
         return True


### PR DESCRIPTION
**Problem:**
The CellProfiler plugin blobdetection.py throws an error at runtime when the module display window option is selected.

**Suggested solution:**
Remove unsupported named keyword argument "dimensions" from the function call to figure.subplot_imshow. The BlobDetection module now exhibits expected behavior.

**Relevant info:**
Error message:
> Error while processing BlobDetection. 
> subplot_imshow got an unexpected keyword argument 'dimensions'. 
> Do you want to stop processing?

Here's the line detailing keyword argument options from CellProfiler's figure class method 'subplot_imshow'. https://github.com/CellProfiler/CellProfiler/blob/master/cellprofiler/gui/figure.py
Lline 1223:
~~~~
    def subplot_imshow(self, x, y, image, title=None, clear=True, colormap=None,
                       colorbar=False, normalize=None, vmin=0, vmax=1,
                       rgb_mask=(1, 1, 1), sharex=None, sharey=None,
                       use_imshow=False, interpolation=None, cplabels=None):
~~~~
