### PR TITLE
change centers and recognize "missing" slices

### DIFF
--- a/measureradialentropy.py
+++ b/measureradialentropy.py
@@ -78,11 +78,11 @@ class MeasurementTemplate(cpm.Module):
 
         indexes = objects.indices
         #Calculate the center of the objects- I'm guessing there's a better way to do this but this was already here
-        #centers, radius = minimum_enclosing_circle(labels, indexes)
+        centers, radius = minimum_enclosing_circle(labels, indexes)
         # minimum_enclosing_circle returns confusing results, b/c if the input objects are not necessarily round then
         # the returned center is frequently not within the object of interest
         my_props = skimage.measure.regionprops(labels)
-        centers = numpy.asarray([props.centroid for props in my_props])
+        #centers = numpy.asarray([props.centroid for props in my_props])
 
         feature = self.get_measurement_name(input_image_name,metric,bins)
         #Do the actual calculation
@@ -162,9 +162,8 @@ class MeasurementTemplate(cpm.Module):
                 slicemeasurements.append(numpy.sum(pixeldict[eachslice]))
         slicemeasurements=numpy.array(slicemeasurements, dtype=float)
         #Calculate entropy, and let scipy handle the normalization for you
-        # mask out the nan values
-        slicemeasurements_mask = numpy.ma.array(slicemeasurements, mask=numpy.isnan(slicemeasurements))
-        entropy=scipy.stats.entropy(slicemeasurements_mask)
+        # ignore the nan values
+        entropy=scipy.stats.entropy(slicemeasurements[~numpy.isnan(slicemeasurements)])
         return entropy, slicemeasurements
 
 

--- a/measureradialentropy.py
+++ b/measureradialentropy.py
@@ -78,11 +78,11 @@ class MeasurementTemplate(cpm.Module):
 
         indexes = objects.indices
         #Calculate the center of the objects- I'm guessing there's a better way to do this but this was already here
-        centers, radius = minimum_enclosing_circle(labels, indexes)
+        #centers, radius = minimum_enclosing_circle(labels, indexes)
         # minimum_enclosing_circle returns confusing results, b/c if the input objects are not necessarily round then
         # the returned center is frequently not within the object of interest
         my_props = skimage.measure.regionprops(labels)
-        #centers = numpy.asarray([props.centroid for props in my_props])
+        centers = numpy.asarray([props.centroid for props in my_props])
 
         feature = self.get_measurement_name(input_image_name,metric,bins)
         #Do the actual calculation

--- a/measureradialentropy.py
+++ b/measureradialentropy.py
@@ -2,12 +2,10 @@
 <b>MeasureRadialEntropy</b> measures the variability of an image's
 intensity inside a certain object
 <hr>
-<p>MeasureRadialEntropy divides an object into pie-shaped wedges and
+<p>MeasureRadialEntropy divides an object into pie-shaped wedges, emanating from the centroid of the object, and
  measures either the mean, median, or integrated intensity of each.  Once the intensity
- of each wedge has been calculated, the entropy of the bin measurements is calculated.</p>
-
- <p>This module is under construction</p>
-
+ of each wedge has been calculated, the entropy of the bin measurements is calculated. It is not guaranteed that every 
+ slice has an intensity value if the centroid of an object lies outside of the object area. In these cases a NAN will be reported.</p>
 '''
 
 
@@ -18,8 +16,6 @@ import skimage.measure
 import cellprofiler.module as cpm
 import cellprofiler.measurement as cpmeas
 import cellprofiler.setting as cps
-
-from centrosome.cpmorphology import minimum_enclosing_circle
 
 ENTROPY = "Entropy"
 
@@ -61,8 +57,11 @@ class MeasurementTemplate(cpm.Module):
         workspace.display_data.statistics = statistics
 
         input_image_name = self.input_image_name.value
+
         input_object_name = self.input_object_name.value
+
         metric = self.intensity_measurement.value
+
         bins = self.bin_number.value
 
         image_set = workspace.image_set
@@ -74,14 +73,13 @@ class MeasurementTemplate(cpm.Module):
         object_set = workspace.object_set
 
         objects = object_set.get_objects(input_object_name)
+
         labels = objects.segmented
 
         indexes = objects.indices
-        #Calculate the center of the objects- I'm guessing there's a better way to do this but this was already here
-        #centers, radius = minimum_enclosing_circle(labels, indexes)
-        # minimum_enclosing_circle returns confusing results, b/c if the input objects are not necessarily round then
-        # the returned center is frequently not within the object of interest
+
         my_props = skimage.measure.regionprops(labels)
+
         centers = numpy.asarray([props.centroid for props in my_props])
 
         feature = self.get_measurement_name(input_image_name,metric,bins)
@@ -92,9 +90,11 @@ class MeasurementTemplate(cpm.Module):
         
         for eachbin in range(bins):
             feature_bin = self.get_measurement_name_bins(input_image_name,metric,bins,eachbin+1)
+
             measurements.add_measurement(input_object_name,feature_bin,slicemeasurements[:,eachbin])
 
         emean = numpy.mean(entropy)
+
         statistics.append([feature, emean])
         
         #add statistics at some point


### PR DESCRIPTION
The MeasureRadialEntropy module was not running as detailed in #25. I identified the problem to be the number of slices an object was divided into was not guaranteed to equal the input parameter. If a slice had no pixels the module would "throw this slice away". An example failing case is if the center of the object is estimated to be outside an object, so far away that none of the labeled object pixels exist to one side. In this case there would be zero pixels for a range of slices.

There are two edits to address this issue. First, the centroid is used in place of the minimum bounding circle center. The minimum bounding circle can be far from from the centroid of the object when the object has "fingers that extend and curve away from the center". Second, when no pixels exist in a slice a place holder NAN value is used instead. This way the number of slices will always be the same.