### PR TITLE
Merge objects shouldn't be considering "self" pixels

### DIFF
--- a/mergeobjects.py
+++ b/mergeobjects.py
@@ -118,9 +118,13 @@ def _merge_neighbors(array, min_obj_size, remove_below_threshold):
 
         # If self is the largest neighbor, then "bincount" will only
         # have one entry in it - the backround at index 0
-        # If the user requests it, we should remove it from the array
-        if len(neighbors) == 1 and remove_below_threshold:
-            max_neighbor = 0
+        if len(neighbors) == 1:
+            # If the user requests it, we should remove it from the array
+            if remove_below_threshold:
+                max_neighbor = 0
+            # Otherwise, we don't want to modify the object
+            else:
+                max_neighbor = n
 
         # Otherwise, we want to set the background to zero and
         # find the largest neighbor

--- a/mergeobjects.py
+++ b/mergeobjects.py
@@ -106,19 +106,28 @@ def _merge_neighbors(array, min_obj_size, remove_below_threshold):
     mask_sizes = (sizes < min_obj_size) & (sizes != 0)
 
     merged = numpy.copy(array)
+
     # Iterate through each small object, determine most significant adjacent neighbor,
     # and merge the object into that neighbor
     for n in numpy.nonzero(mask_sizes)[0]:
         mask = array == n
-        # "Thick" mode ensures the border bleeds into the neighboring objects
-        bound = skimage.segmentation.find_boundaries(mask, mode='thick')
+
+        # "Outer" mode ensures we're only getting pixels beyond the object
+        bound = skimage.segmentation.find_boundaries(mask, mode='outer')
         neighbors = numpy.bincount(array[bound].ravel())
-        # If self is the largest neighbor, the object should be removed
-        if len(neighbors) >= n and remove_below_threshold:
-            neighbors[n] = 0
-        # Background should be set to 0
-        neighbors[0] = 0
-        max_neighbor = numpy.argmax(neighbors)
+
+        # If self is the largest neighbor, then "bincount" will only
+        # have one entry in it - the backround at index 0
+        # If the user requests it, we should remove it from the array
+        if len(neighbors) == 1 and remove_below_threshold:
+            max_neighbor = 0
+
+        # Otherwise, we want to set the background to zero and
+        # find the largest neighbor
+        else:
+            neighbors[0] = 0
+            max_neighbor = numpy.argmax(neighbors)
+
         # Set object value to largest neighbor
         merged[merged == n] = max_neighbor
     return merged

--- a/tests/test_mergeobjects.py
+++ b/tests/test_mergeobjects.py
@@ -175,7 +175,7 @@ def test_pass_3d_merge_large_object(volume_labels, module, object_set_empty, obj
 def test_2d_keep_nonneighbored_objects(image_labels, module, object_set_empty, objects_empty, workspace_empty):
     labels = image_labels.copy()
     # Create "small"
-    labels[0:3, 4:6] = 8
+    labels[8:12, 9:11] = 8
 
     objects_empty.segmented = labels
 
@@ -196,7 +196,7 @@ def test_2d_keep_nonneighbored_objects(image_labels, module, object_set_empty, o
 
 def test_3d_keep_nonneighbored_object(volume_labels, module, object_set_empty, objects_empty, workspace_empty):
     labels = volume_labels.copy()
-    labels[0:3, 0:3, 4:6] = 8
+    labels[8:12, 9:11, 4:6] = 8
 
     objects_empty.segmented = labels
 


### PR DESCRIPTION
Previously, the `thick` method for finding borders was adding pixels from the object we were trying to merge, making the algorithm think that itself was always the largest object. Changing the mode to `outer` and changing how an isolated object is detected fixes this. 