### PR TITLE
Refactor tests so a new instance of a module is given on each run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def image(request):
     return cellprofiler.image.Image(image=data, dimensions=dimensions)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def image_empty():
     image = cellprofiler.image.Image()
 
@@ -71,11 +71,12 @@ def measurements():
     return cellprofiler.measurement.Measurements()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def module(request):
     instance = getattr(request.module, "instance")
 
-    return instance
+    return instance()
+
 
 @pytest.fixture(scope="function")
 def objects(image):

--- a/tests/test_blobdetection.py
+++ b/tests/test_blobdetection.py
@@ -35,7 +35,7 @@ def image(request):
     return cellprofiler.image.Image(image=data, dimensions=dimensions)
 
 
-instance = blobdetection.BlobDetection()
+instance = blobdetection.BlobDetection
 
 
 def test_run_dog(image, image_set, module, workspace):

--- a/tests/test_edgedetection.py
+++ b/tests/test_edgedetection.py
@@ -7,7 +7,7 @@ import skimage.filters
 
 import edgedetection
 
-instance = edgedetection.EdgeDetection()
+instance = edgedetection.EdgeDetection
 
 
 def test_run_without_mask(image, image_set, module, workspace):

--- a/tests/test_gammacorrection.py
+++ b/tests/test_gammacorrection.py
@@ -3,7 +3,7 @@ import skimage.exposure
 
 import gammacorrection
 
-instance = gammacorrection.GammaCorrection()
+instance = gammacorrection.GammaCorrection
 
 
 def test_run(image, module, image_set, workspace):

--- a/tests/test_histogramequalization.py
+++ b/tests/test_histogramequalization.py
@@ -5,7 +5,7 @@ import skimage.exposure
 
 import histogramequalization
 
-instance = histogramequalization.HistogramEqualization()
+instance = histogramequalization.HistogramEqualization
 
 
 def test_run(image, image_set, module, workspace):

--- a/tests/test_imagegradient.py
+++ b/tests/test_imagegradient.py
@@ -6,7 +6,7 @@ import skimage.morphology
 
 import imagegradient
 
-instance = imagegradient.ImageGradient()
+instance = imagegradient.ImageGradient
 
 
 def test_run(image, module, image_set, workspace):

--- a/tests/test_laplacianofgaussian.py
+++ b/tests/test_laplacianofgaussian.py
@@ -5,7 +5,7 @@ import skimage.color
 
 import laplacianofgaussian
 
-instance = laplacianofgaussian.LaplacianOfGaussian()
+instance = laplacianofgaussian.LaplacianOfGaussian
 
 
 def test_run(image, image_set, module, workspace):

--- a/tests/test_mergeobjects.py
+++ b/tests/test_mergeobjects.py
@@ -7,7 +7,7 @@ import pytest
 import mergeobjects
 
 
-instance = mergeobjects.MergeObjects()
+instance = mergeobjects.MergeObjects
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_randomwalkeralgorithm.py
+++ b/tests/test_randomwalkeralgorithm.py
@@ -7,7 +7,7 @@ import skimage.segmentation
 import randomwalkeralgorithm
 
 
-instance = randomwalkeralgorithm.RandomWalkerAlgorithm()
+instance = randomwalkeralgorithm.RandomWalkerAlgorithm
 
 
 def test_run(image, module, workspace):

--- a/tests/test_tophattransform.py
+++ b/tests/test_tophattransform.py
@@ -6,7 +6,7 @@ import skimage.morphology
 
 import tophattransform
 
-instance = tophattransform.TopHatTransform()
+instance = tophattransform.TopHatTransform
 
 
 @pytest.fixture(


### PR DESCRIPTION
This was making it so changes to the settings of the module in other tests would affect downstream tests. 

Now, every test is given a fresh instance of the module with no history attached to it. 