### PR TITLE
MergeObjects - minimum contact area option

### DIFF
--- a/mergeobjects.py
+++ b/mergeobjects.py
@@ -137,7 +137,7 @@ def _merge_neighbors(array, min_obj_size, remove_below_threshold, min_neighbor_s
                 max_neighbor = 0
             # Otherwise, we don't want to modify the object
             else:
-                max_neighbor = n
+                continue
 
         # Otherwise, we want to set the background to zero and
         # find the largest neighbor

--- a/tests/test_mergeobjects.py
+++ b/tests/test_mergeobjects.py
@@ -63,9 +63,6 @@ def test_run(object_set_with_data, module, workspace_with_data, remove_below, ne
     module.remove_below_threshold.value = remove_below
     module.min_neighbor_size.value = neighbor_size
 
-    if not remove_below:
-        print("here")
-
     module.run(workspace_with_data)
 
     actual = workspace_with_data.object_set.get_objects("OutputObjects").segmented
@@ -91,7 +88,7 @@ def test_run(object_set_with_data, module, workspace_with_data, remove_below, ne
             if remove_below:
                 max_neighbor = 0
             else:
-                max_neighbor = n
+                continue
         else:
             neighbors[0] = 0
             max_neighbor = numpy.argmax(neighbors)


### PR DESCRIPTION
This adds a "minimum contact area" option to the MergeObjects module (requested by @derekthirstrup). 

Essentially, objects have to be above this minimum contact area in order to merge. This prevents an object from merging into another object it shares a single pixel with.