### PR TITLE
Fix caching section for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ addons:
     packages:
       - libhdf5-serial-dev
       - python-pip
+cache:
   apt: true
   directories: $HOME/.cache/pip
 dist: trusty


### PR DESCRIPTION
It looks like the `cache` key was missing in the YAML and this caused some parse issues in Travis CI - hope this helps!