### PR TITLE
Fixes issues #65 and #70, further changes to more current Keras interface

### DIFF
--- a/classifypixelsunet.py
+++ b/classifypixelsunet.py
@@ -153,8 +153,7 @@ def get_core(dim1, dim2):
     # UP
 
     d = keras.layers.UpSampling2D()(d)
-
-    y = keras.layers.merge([d, c], concat_axis=3, mode="concat")
+    y = keras.layers.merge.concatenate([d, c], axis=3)
 
     e = keras.layers.Convolution2D(256, 3, 3, **option_dict_conv)(y)
     e = keras.layers.BatchNormalization(**option_dict_bn)(e)
@@ -164,7 +163,7 @@ def get_core(dim1, dim2):
 
     e = keras.layers.UpSampling2D()(e)
 
-    y = keras.layers.merge([e, b], concat_axis=3, mode="concat")
+    y = keras.layers.merge.concatenate([e, b], axis=3)
 
     f = keras.layers.Convolution2D(128, 3, 3, **option_dict_conv)(y)
     f = keras.layers.BatchNormalization(**option_dict_bn)(f)
@@ -173,8 +172,8 @@ def get_core(dim1, dim2):
     f = keras.layers.BatchNormalization(**option_dict_bn)(f)
 
     f = keras.layers.UpSampling2D()(f)
-
-    y = keras.layers.merge([f, a], concat_axis=3, mode="concat")
+    
+    y = keras.layers.merge.concatenate([f, a], axis=3)
 
     y = keras.layers.Convolution2D(64, 3, 3, **option_dict_conv)(y)
     y = keras.layers.BatchNormalization(**option_dict_bn)(y)

--- a/classifypixelsunet.py
+++ b/classifypixelsunet.py
@@ -2,6 +2,7 @@
 
 """
 Author: Tim Becker, Juan Caicedo, Claire McQuinn 
+some modifications by Volker Hilsenstein incorporating code snippets from Eric Czech
 """
 
 import logging
@@ -14,6 +15,7 @@ import time
 import os.path
 import cellprofiler.module
 import cellprofiler.setting
+from skimage import transform 
 
 if sys.platform.startswith('win'):
     os.environ["KERAS_BACKEND"] = "cntk"
@@ -24,8 +26,8 @@ import keras
 
 logger = logging.getLogger(__name__)
 
-option_dict_conv = {"activation": "relu", "border_mode": "same"}
-option_dict_bn = {"mode": 0, "momentum": 0.9}
+option_dict_conv = {"activation": "relu", "padding": "same"}
+option_dict_bn = { "momentum": 0.9}
 
 
 __doc__ = """\
@@ -47,7 +49,8 @@ replace the model the function  download_file_from_google_drive needs to
 be updated.  
 
 
-Author: Tim Becker, Juan Caicedo, Claire McQuinn 
+Author: Tim Becker, Juan Caicedo, Claire McQuinn
+some modifications by Volker Hilsenstein incorporating code snippets from Eric Czech
 """
 
 
@@ -70,10 +73,20 @@ class ClassifyPixelsUnet(cellprofiler.module.ImageProcessing):
         super(ClassifyPixelsUnet, self).run(workspace)
 
 
-def unet_initialize(input_shape):
-    # create model
+def unet_initialize(input_shape, automated_shape_adjustment=True):
+    """initialize a unet of size shape, with optiaonel size adjustment if necessary
 
-    dim1, dim2 = input_shape
+    Args: 
+        input_shape: tuple 
+        automated_shapte_adjustemt: boolean flag, if True shape will be adjusted to a compatible shape
+    """ 
+    unet_shape = unet_shape_resize(input_shape, 3)
+    if input_shape != unet_shape and not automated_shape_adjustment:
+        raise ValueError(
+            f"Shape {input_shape} not compatible with 3 max-pool layers. Consider setting automated_shape_adjustment=True.")
+    
+    # create model
+    dim1, dim2 = unet_shape
 
     # build model
     model = get_model_3_class(dim1, dim2)
@@ -99,6 +112,43 @@ def unet_initialize(input_shape):
 
     return model
 
+def unet_shape_resize(shape, n_pooling_layers):
+    """Resize shape for compatibility with UNet architecture
+    
+    Args:
+        shape: Shape of images to be resized in format HW[D1, D2, ...] where any 
+            trailing dimensions after the first two are ignored
+        n_pooling_layers: Number of pooling (or upsampling) layers in network
+    Returns:
+        Shape with HW sizes transformed to nearest value acceptable by network
+
+    suggested by Eric Czech
+    """
+    base = 2**n_pooling_layers
+    rcsh = np.round(np.array(shape[:2]) / base).astype(int)
+    # Combine HW axes transformation with trailing shape dimensions 
+    # (being careful not to return 0-length axes)
+    return tuple(base * np.clip(rcsh, 1, None)) + tuple(shape[2:])
+    
+def unet_image_resize(image, n_pooling_layers):
+    """Resize image for compatibility with UNet architecture
+
+    Args:
+        image: Image to be resized in format HW[D1, D2, ...] where any 
+            trailing dimensions after the first two are ignored
+        n_pooling_layers: Number of pooling (or upsampling) layers in network
+    Returns:
+        Image with HW dimensions resized to nearest value acceptable by network
+    
+    Reference + Author:
+        Eric Czech
+        https://github.com/CellProfiler/CellProfiler-plugins/issues/65
+    """
+    shape = unet_shape_resize(image.shape, n_pooling_layers)
+    # Note here that the type and range of the image will either not change
+    # or become float64, 0-1 (which makes no difference w/ subsequent min/max scaling)
+    return image if shape == image.shape else transform.resize(
+        image, shape, mode='reflect', anti_aliasing=True)
 
 def unet_classify(model, input_image):
     dim1, dim2 = input_image.shape
@@ -116,38 +166,63 @@ def unet_classify(model, input_image):
 
     return pixel_classification[0, :, :, :]
 
+def unet_classify(model, input_image, resize_to_model=True):
+    dim1, dim2 = input_image.shape
+    mdim1, mdim2 = model.input_shape[1:3]
+    needs_resize = False if (dim1, dim2) == (mdim1, mdim2) else True
+    if needs_resize:
+        if resize_to_model:
+            input_image = transform.resize(input_image, (mdim1, mdim2), anti_aliasing=True)
+        else:
+            raise ValueError("image size does not match model size, set resize_to_model=True")
+    images = input_image.reshape((-1, mdim1, mdim2, 1))
+    
+    # scale min, max to [0.0,1.0]
+    images = images.astype(numpy.float32)
+    images = images - numpy.min(images)
+    images = images.astype(numpy.float32) / numpy.max(images)
+    
+    start = time.time()
+    pixel_classification = model.predict(images, batch_size=1)
+    end = time.time()
+    logger.debug('UNet segmentation took {} seconds '.format(end - start))
+
+    retval = pixel_classification[0, :, :, :]
+    if needs_resize:
+        retval = transform.resize(retval, (dim1, dim2, retval.shape[2]))
+    return retval
 
 def get_core(dim1, dim2):
     x = keras.layers.Input(shape=(dim1, dim2, 1))
-
-    a = keras.layers.Convolution2D(64, 3, 3, **option_dict_conv)(x)
+    
+    a = keras.layers.Conv2D(64, (3, 3) , **option_dict_conv)(x)
     a = keras.layers.BatchNormalization(**option_dict_bn)(a)
 
-    a = keras.layers.Convolution2D(64, 3, 3, **option_dict_conv)(a)
+    a = keras.layers.Conv2D(64, (3, 3), **option_dict_conv)(a)
     a = keras.layers.BatchNormalization(**option_dict_bn)(a)
 
     y = keras.layers.MaxPooling2D()(a)
 
-    b = keras.layers.Convolution2D(128, 3, 3, **option_dict_conv)(y)
+    b = keras.layers.Conv2D(128, (3, 3), **option_dict_conv)(y)
     b = keras.layers.BatchNormalization(**option_dict_bn)(b)
 
-    b = keras.layers.Convolution2D(128, 3, 3, **option_dict_conv)(b)
+    b = keras.layers.Conv2D(128, (3, 3), **option_dict_conv)(b)
     b = keras.layers.BatchNormalization(**option_dict_bn)(b)
 
     y = keras.layers.MaxPooling2D()(b)
 
-    c = keras.layers.Convolution2D(256, 3, 3, **option_dict_conv)(y)
+    c = keras.layers.Conv2D(256, (3, 3), **option_dict_conv)(y)
     c = keras.layers.BatchNormalization(**option_dict_bn)(c)
 
-    c = keras.layers.Convolution2D(256, 3, 3, **option_dict_conv)(c)
+    c = keras.layers.Conv2D(256, (3, 3), **option_dict_conv)(c)
     c = keras.layers.BatchNormalization(**option_dict_bn)(c)
 
     y = keras.layers.MaxPooling2D()(c)
 
-    d = keras.layers.Convolution2D(512, 3, 3, **option_dict_conv)(y)
+    d = keras.layers.Conv2D(512, (3, 3), **option_dict_conv)(y)
     d = keras.layers.BatchNormalization(**option_dict_bn)(d)
 
-    d = keras.layers.Convolution2D(512, 3, 3, **option_dict_conv)(d)
+    d = keras.layers.Conv2D(512, (3, 3), **option_dict_conv)(d)
     d = keras.layers.BatchNormalization(**option_dict_bn)(d)
 
     # UP
@@ -155,39 +230,38 @@ def get_core(dim1, dim2):
     d = keras.layers.UpSampling2D()(d)
     y = keras.layers.merge.concatenate([d, c], axis=3)
 
-    e = keras.layers.Convolution2D(256, 3, 3, **option_dict_conv)(y)
+    e = keras.layers.Conv2D(256, (3, 3), **option_dict_conv)(y)
     e = keras.layers.BatchNormalization(**option_dict_bn)(e)
 
-    e = keras.layers.Convolution2D(256, 3, 3, **option_dict_conv)(e)
+    e = keras.layers.Conv2D(256, (3, 3), **option_dict_conv)(e)
     e = keras.layers.BatchNormalization(**option_dict_bn)(e)
 
     e = keras.layers.UpSampling2D()(e)
 
     y = keras.layers.merge.concatenate([e, b], axis=3)
 
-    f = keras.layers.Convolution2D(128, 3, 3, **option_dict_conv)(y)
+    f = keras.layers.Conv2D(128, (3, 3), **option_dict_conv)(y)
     f = keras.layers.BatchNormalization(**option_dict_bn)(f)
 
-    f = keras.layers.Convolution2D(128, 3, 3, **option_dict_conv)(f)
+    f = keras.layers.Conv2D(128, (3, 3), **option_dict_conv)(f)
     f = keras.layers.BatchNormalization(**option_dict_bn)(f)
 
     f = keras.layers.UpSampling2D()(f)
     
     y = keras.layers.merge.concatenate([f, a], axis=3)
 
-    y = keras.layers.Convolution2D(64, 3, 3, **option_dict_conv)(y)
+    y = keras.layers.Conv2D(64, (3, 3), **option_dict_conv)(y)
     y = keras.layers.BatchNormalization(**option_dict_bn)(y)
 
-    y = keras.layers.Convolution2D(64, 3, 3, **option_dict_conv)(y)
+    y = keras.layers.Conv2D(64, (3, 3), **option_dict_conv)(y)
     y = keras.layers.BatchNormalization(**option_dict_bn)(y)
 
     return [x, y]
 
-
 def get_model_3_class(dim1, dim2, activation="softmax"):
     [x, y] = get_core(dim1, dim2)
 
-    y = keras.layers.Convolution2D(3, 1, 1, **option_dict_conv)(y)
+    y = keras.layers.Conv2D(3, (1, 1), **option_dict_conv)(y)
 
     if activation is not None:
         y = keras.layers.Activation(activation)(y)

--- a/classifypixelsunet.py
+++ b/classifypixelsunet.py
@@ -149,22 +149,7 @@ def unet_image_resize(image, n_pooling_layers):
     # or become float64, 0-1 (which makes no difference w/ subsequent min/max scaling)
     return image if shape == image.shape else transform.resize(
         image, shape, mode='reflect', anti_aliasing=True)
-
-def unet_classify(model, input_image):
-    dim1, dim2 = input_image.shape
-
-    images = input_image.reshape((-1, dim1, dim2, 1))
-
-    images = images.astype(numpy.float32)
-    images = images - numpy.min(images)
-    images = images.astype(numpy.float32) / numpy.max(images)
-
-    start = time.time()
-    pixel_classification = model.predict(images, batch_size=1)
-    end = time.time()
-    logger.debug('UNet segmentation took {} seconds '.format(end - start))
-
-    return pixel_classification[0, :, :, :]
+        
 
 def unet_classify(model, input_image, resize_to_model=True):
     dim1, dim2 = input_image.shape

--- a/classifypixelsunet.py
+++ b/classifypixelsunet.py
@@ -83,7 +83,7 @@ def unet_initialize(input_shape, automated_shape_adjustment=True):
     unet_shape = unet_shape_resize(input_shape, 3)
     if input_shape != unet_shape and not automated_shape_adjustment:
         raise ValueError(
-            f"Shape {input_shape} not compatible with 3 max-pool layers. Consider setting automated_shape_adjustment=True.")
+            "Input shape not compatible with 3 max-pool layers. Consider setting automated_shape_adjustment=True.")
     
     # create model
     dim1, dim2 = unet_shape

--- a/classifypixelsunet.py
+++ b/classifypixelsunet.py
@@ -11,7 +11,7 @@ import pkg_resources
 import requests
 import sys
 import time
-
+import numpy as np
 import os.path
 import cellprofiler.module
 import cellprofiler.setting
@@ -149,7 +149,7 @@ def unet_image_resize(image, n_pooling_layers):
     # or become float64, 0-1 (which makes no difference w/ subsequent min/max scaling)
     return image if shape == image.shape else transform.resize(
         image, shape, mode='reflect', anti_aliasing=True)
-        
+
 
 def unet_classify(model, input_image, resize_to_model=True):
     dim1, dim2 = input_image.shape


### PR DESCRIPTION
These are more exhaustive changes to my earlier pull request to fix both 

https://github.com/CellProfiler/CellProfiler-plugins/issues/65
https://github.com/CellProfiler/CellProfiler-plugins/issues/70

It incorporates some of the code snippets suggested by @eric-czech.
* When a model is initialiased, the model size is now scaled to the closest compatible size.
* Any images that are fed to the model are first resized to match the input size of the model (if needed)

* If resizing took place, the predictions are resized to the original input images shape.
