### PR TITLE
Set the size of the background to zero

### DIFF
--- a/mergeobjects.py
+++ b/mergeobjects.py
@@ -180,6 +180,8 @@ by default.
 def _merge_neighbors(array, min_obj_size, remove_below_threshold, use_contact_area,
                      contact_area_method, abs_neighbor_size, rel_neighbor_size):
     sizes = numpy.bincount(array.ravel())
+    # Set the background to zero
+    sizes[0] = 0
     # Find the indices of all objects below threshold
     mask_sizes = (sizes < min_obj_size) & (sizes != 0)
 


### PR DESCRIPTION
If the minimum object size is greater than the background pixel volume, then the background will also be included as an "object to merge". When calculating relative surface area, this would cause a divide by zero error to occur. Since the background isn't technically an object we want to merge, just set it to zero so it isn't considered.