### PR TITLE
Travis CI: Add flake8 to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,17 @@ install:
 language: python
 notifications:
   email: false
-python: 2.7
+python:
+  - 2.7
+  - 3.6
+matrix:
+  allow_failures:
+    - python: 3.6
+before_script:
+  - pip install flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script: pytest
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ notifications:
 python:
   - 2.7
   - 3.6
-matrix:
-  allow_failures:
-    - python: 3.6
 before_script:
   - pip install flake8
   # stop the build if there are Python syntax errors or undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ notifications:
 python:
   - 2.7
   - 3.6
+matrix:
+  allow_failures:
+    - python: 3.6
 before_script:
   - pip install flake8
   # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree