### PR TITLE
Iterative approach to new scikit-image active contour methods

### DIFF
--- a/activecontourmodel.py
+++ b/activecontourmodel.py
@@ -135,17 +135,17 @@ class ActiveContourModel(cellprofiler.module.ImageSegmentation):
 
         # Geodesic settings
         self.balloon = cellprofiler.setting.Float(
-            text="Ballon force",
+            text="Balloon force",
             value=0.
         )
 
         # Morph Chan-Vese settings
-        self.lambda1 = cellprofiler.setting.Float(
+        self.outer_weight = cellprofiler.setting.Float(
             text="Outer region weight",
             value=1.
         )
 
-        self.lambda2 = cellprofiler.setting.Float(
+        self.inner_weight = cellprofiler.setting.Float(
             text="Inner region weight",
             value=1.
         )
@@ -173,8 +173,8 @@ class ActiveContourModel(cellprofiler.module.ImageSegmentation):
             self.checkerboard_size,
             self.smoothing,
             self.balloon,
-            self.lambda1,
-            self.lambda2
+            self.outer_weight,
+            self.inner_weight
         ]
 
     def visible_settings(self):
@@ -235,8 +235,8 @@ class ActiveContourModel(cellprofiler.module.ImageSegmentation):
                 ]
             elif self.method.value == MORPH_CHAN_VESE_METHOD:
                 __settings__ += [
-                    self.lambda1,
-                    self.lambda2
+                    self.outer_weight,
+                    self.inner_weight
                 ]
         return __settings__
 
@@ -319,8 +319,8 @@ class ActiveContourModel(cellprofiler.module.ImageSegmentation):
                                              iterations=self.iterations.value,
                                              smoothing=self.smoothing.value,
                                              init_level_set=level_set,
-                                             lambda1=self.lambda1.value,
-                                             lambda2=self.lambda2.value
+                                             lambda1=self.outer_weight.value,
+                                             lambda2=self.inner_weight.value
                                              )
 
         y_data = skimage.measure.label(y_data, connectivity=self.connectivity.value)

--- a/activecontourmodel.py
+++ b/activecontourmodel.py
@@ -386,7 +386,7 @@ class ActiveContourModel(cellprofiler.module.ImageSegmentation):
             return skimage.segmentation.circle_level_set(shape, center=center, radius=radius)
 
         elif self.level_set.value == LEVEL_SET_CHECKERBOARD:
-            square_size = int(numpy.ceil(self.level_set_size.value)) if size is not None else size
+            square_size = int(numpy.ceil(self.level_set_size.value)) if size is None else size
             return skimage.segmentation.checkerboard_level_set(shape, square_size=square_size)
 
     def run_morphological_operations(self, data, size=None, iterations=None):


### PR DESCRIPTION
scikit-image's newer (as of 0.14) active contour segmentation methods [morphological geodesic](http://scikit-image.org/docs/dev/api/skimage.segmentation.html#skimage.segmentation.morphological_geodesic_active_contour) and [morphological chan-vese](http://scikit-image.org/docs/dev/api/skimage.segmentation.html#skimage.segmentation.morphological_chan_vese) both require an initial level set geometry and size. Generally the geometry is specific to the segmentation task, but the ideal level set size may differ between images within the same class. By default, these algorithms are naive to what is considered the "foreground" and the "background"; this is determined entirely by the level set specifications. We've found that some of our images given a certain level set segment properly, but other images will have the foreground/background relationship inverted (for more details, see scikit-image/scikit-image#3183).

This is a major refactor of the active contours module to allow multiple level set sizes to be chosen for a given image. If this iterative option is selected, the module will first attempt to run the segmentation at that size for a few iterations, then check the foreground/background relationship based on the median intensity of the original image. If the inverse of the diagnostic segmentation has a higher median intensity, that indicates that the FG/BG might be inverted. The module will then attempt to use the next supplied level set size for a diagnostic segmentation, and repeat the process until a suitable size is found. If no suitable size is found, an error is thrown. 

@derekthirstrup and I have found this to be generally effective for certain images that were failing to segment properly with a single size supplied. 