### PR TITLE
Travis CI: Add more flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
 before_script:
   - pip install flake8
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,14 @@ addons:
   apt:
     packages:
       - libhdf5-serial-dev
-      - python-pip
 cache:
   apt: true
   directories: $HOME/.cache/pip
-dist: trusty
 env:
   - LC_ALL="en_US.UTF-8" CP_MYSQL_TEST_HOST="127.0.0.1" CP_MYSQL_TEST_USER="root" CP_MYSQL_TEST_PASSWORD=""
 install:
   - pip install --upgrade pip
-  - pip install --upgrade cython
-  - pip install --upgrade joblib
-  - pip install --upgrade numpy
-  - pip install --upgrade scipy
+  - pip install --upgrade cython joblib numpy pathlib2 scipy
   - pip install --editable git+https://github.com/CellProfiler/CellProfiler.git#egg=CellProfiler
   - pip freeze
 language: python
@@ -33,4 +28,3 @@ before_script:
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script: pytest
-sudo: false


### PR DESCRIPTION
On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__python/black__](https://github.com/python/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.