### PR TITLE
Allow cellprob_threshold to take on values between -6 and 6 in RunCellPose

### DIFF
--- a/runcellpose.py
+++ b/runcellpose.py
@@ -186,7 +186,8 @@ If you have multiple GPUs on your system, this button will only test the first o
         self.dist_threshold = Float(
             text="Cell probability threshold",
             value=0.0,
-            minval=0,
+            minval=-6.0,
+            maxval=6.0,
             doc=f"""\
 Cell probability threshold (all pixels with probability above threshold kept for masks). Recommended default is 0.0. """,
         )


### PR DESCRIPTION
Related to issue #128 and PR #129. Previously RunCellPose provided an error if user chose negative values for the cellprob_threshold. In this PR we allow this threshold to have values between -6 and 6, as explained in the [CellPose docs](https://cellpose.readthedocs.io/en/latest/settings.html#cell-probability-threshold). 