### PR TITLE
RunImageJScript: improve param behavior

### DIFF
--- a/cpij/server.py
+++ b/cpij/server.py
@@ -209,7 +209,7 @@ def convert_java_type_to_setting(param_name, param_type, param_class):
                 browse_msg=f'Choose {param_label} file'
                 )
             return (param_dir, param_file)
-        elif bool((img_string for img_string in img_strings if type_string == img_string)):
+        elif type_string in img_strings:
             return ImageSubscriber(param_label)
     elif OUTPUT_CLASS == param_class:
         if bool((img_string for img_string in img_strings if type_string == img_string)):

--- a/runimagejscript.py
+++ b/runimagejscript.py
@@ -504,6 +504,12 @@ Note: this must be done each time you change the script, before running the Cell
     def run(self, workspace):
         self.init_pyimagej()
 
+        # Unwrap the current settings from their SettingsGroups
+        all_settings = list(map(lambda x: x.settings[0], self.script_parameter_list))
+        # Update the script input/output settings in case any were removed from the GUI
+        self.script_input_settings = {k: v for (k,v) in self.script_input_settings.items() if v in all_settings}
+        self.script_output_settings = {k: v for (k,v) in self.script_output_settings.items() if v in all_settings}
+
         if self.show_window:
             workspace.display_data.script_input_pixels = {}
             workspace.display_data.script_input_dimensions = {}


### PR DESCRIPTION
Fixes two bugs in the RunImageJScript:
* Non-image parameters are no longer being aggressively claimed as images
* Deleting parameters should now remove them appropriately