### PR TITLE
Update Cellpose model

### DIFF
--- a/runcellpose.py
+++ b/runcellpose.py
@@ -349,7 +349,7 @@ The default is set to "Yes".
                     % model_path, self.model_file_name,
                 )
             try:
-                model = models.CellposeModel(pretrained_model=model_path, gpu=self.use_gpu.value)
+                model = models.Cellpose(pretrained_model=model_path, gpu=self.use_gpu.value)
             except:
                 raise ValidationError(
                     "Failed to load custom model: %s "
@@ -365,17 +365,17 @@ The default is set to "Yes".
                 model_file = self.model_file_name.value
                 model_directory = self.model_directory.get_absolute_path()
                 model_path = os.path.join(model_directory, model_file)
-                model = models.CellposeModel(pretrained_model=model_path, gpu=self.use_gpu.value)
+                model = models.Cellpose(pretrained_model=model_path, gpu=self.use_gpu.value)
 
         else:
             if self.mode.value != 'custom':
-                model = models.CellposeModel(model_type= self.mode.value,
+                model = models.Cellpose(model_type= self.mode.value,
                                         gpu=self.use_gpu.value)
             else:
                 model_file = self.model_file_name.value
                 model_directory = self.model_directory.get_absolute_path()
                 model_path = os.path.join(model_directory, model_file)
-                model = models.CellposeModel(pretrained_model=model_path, gpu=self.use_gpu.value)
+                model = models.Cellpose(pretrained_model=model_path, gpu=self.use_gpu.value)
 
         if self.use_gpu.value and model.torch:
             from torch import cuda


### PR DESCRIPTION
This PR is to update the runcellpose.py to call models using `model.Cellpose` instead of `model.CellposeModel`.

The main difference between the two, as found by @roshankern, is as follows:

Based on the latest documentation (https://cellpose.readthedocs.io/en/latest/models.html) that a model loaded with CellposeModel() does not estimate the ROI size if diameter is set to 0 -- only a model loaded from Cellpose() will estimate the cell diameter.

> Under "Full Built-in Models"(https://cellpose.readthedocs.io/en/latest/models.html#full-built-in-models):
These models can be loaded and used in the notebook with models.Cellpose(model_type='cyto') or in the command line with python -m cellpose --pretrained_model cyto.
These models have a size model and 4 different training versions, each trained starting from 4 different random initial parameter sets. This means you can run with diameter=0 or --diameter 0 and the model can estimate the ROI size.

> Under "Other Built-In Models"(https://cellpose.readthedocs.io/en/latest/models.html#other-built-in-models):
These models do not have a size model and 4 different training versions. If the diameter is set to 0.0, then the model uses the default diam_mean for the diameter (30.0).
These models can be loaded and used in the notebook with e.g. models.CellposeModel(model_type='tissuenet') or models.CellposeModel(model_type='LC2'), or in the command line with python -m cellpose --pretrained_model tissuenet.