### PR TITLE
Allow pip installation, but also CellProfiler loading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,41 @@
 from setuptools import setup
 import setuptools
 
-install_deps = [
-    "cellprofiler",
-    "cellprofiler-core",
-            ]
+if __name__!="__main__":
+    print("Please change your plugins folder to the 'active plugins' subfolder")
 
-cellpose_deps = [
-    "cellpose>=1.0.2"
-]
+else:
+    install_deps = [
+        "cellprofiler",
+        "cellprofiler-core",
+                ]
 
-omnipose_deps = [
-    "omnipose",
-    "ncolor"
-]
+    cellpose_deps = [
+        "cellpose>=1.0.2"
+    ]
 
-stardist_deps = [
-    "tensorflow",
-    "stardist"
-]
+    omnipose_deps = [
+        "omnipose",
+        "ncolor"
+    ]
 
-imagejscript_deps = [
-    "pyimagej"
-]
+    stardist_deps = [
+        "tensorflow",
+        "stardist"
+    ]
 
-setup(
-    name="cellprofiler_plugins",
-    packages=setuptools.find_packages(),
-    install_requires = install_deps,
-    extras_require = {
-      "cellpose": cellpose_deps,
-      "omnipose": omnipose_deps,
-      "stardist": stardist_deps,
-      "imagejscript": imagejscript_deps,
-    }
-)
+    imagejscript_deps = [
+        "pyimagej"
+    ]
+
+    setup(
+        name="cellprofiler_plugins",
+        packages=setuptools.find_packages(),
+        install_requires = install_deps,
+        extras_require = {
+          "cellpose": cellpose_deps,
+          "omnipose": omnipose_deps,
+          "stardist": stardist_deps,
+          "imagejscript": imagejscript_deps,
+        }
+    )


### PR DESCRIPTION
Disclaimer - this is gross, and I feel gross about it, but it might be the least-worst thing

So if you had the CellProfiler-plugins repo at a pre-reorg commit, you probably had the CellProfiler preference for "where are the plugins" set to the top level, since that's where plugins previously were, and there was not previously a setup.py file. 

Now there IS a setup.py file, and the plugins have moved to the `active_plugins` subfolder, if you still have your plugin-location-preference set to the top level folder, CellProfiler will just point-blank refuse to open, with the error message below. Only moving the setup.py file (or the whole folder) allows you to let CellProfiler open, at which point you could then update the plugin-location-preference, but if you don't know to do that, then you don't know to do that. 

This change allows the user to get an error message that a) doesn't bonk CellProfiler at keep it from opening and b) tells them how they can actually get the plugins, while still c) allowing the various pip install commands to work as normal. Therefore, I think while gross, it might be worth doing anyway. 

```
usage: __main__.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: __main__.py --help [cmd1 cmd2 ...]
   or: __main__.py --help-commands
   or: __main__.py cmd --help

error: no commands supplied
```

