### PR TITLE
Runilastik module that can use local OR Docker installations

### DIFF
--- a/active_plugins/Runilastik_test.py
+++ b/active_plugins/Runilastik_test.py
@@ -48,43 +48,14 @@ processing. For example, use **IdentifyPrimaryObjects** on a
 of the channels in **ColorToGray** is the same as the order of the
 labels within the ilastik project.
 
-CellProfiler automatically scales grayscale and color images to the
-[0.0, 1.0] range on load. Your ilastik classifier should be trained on
-images with the same scale as the prediction images. You can ensure
-consistent scales by:
-
--  using **ImageMath** to convert the images loaded by CellProfiler back
-   to their original scale. Use these settings to rescale an image:
-
-   -  **Operation**: *None*
-   -  **Multiply the first image by**: *RESCALE_VALUE*
-   -  **Set values greater than 1 equal to 1?**: *No*
-
-   where *RESCALE_VALUE* is determined by your image data and the value
-   of *Set intensity range from* in **NamesAndTypes**. For example, the
-   *RESCALE_VALUE* for 32-bit images rescaled by "*Image bit-depth*" is
-   65535 (the maximum value allowed by this data type). Please refer to
-   the help for the setting *Set intensity range from* in
-   **NamesAndTypes** for more information.
-
-   This option is best when your training and prediction images do not
-   require any preprocessing by CellProfiler.
-
--  preprocessing any training images with CellProfiler (e.g.,
-   **RescaleIntensity**) and applying the same pre-processing steps to
-   your analysis pipeline. You can use **SaveImages** to export training
-   images as 32-bit TIFFs.
-
-   This option requires two CellProfiler pipelines, but is effective
-   when your training and prediction images require preprocessing by
-   CellProfiler.
-
 Additionally, please ensure CellProfiler is configured to load images in
 the same format as ilastik. For example, if your ilastik classifier is
 trained on RGB images, use **NamesAndTypes** to load images as RGB by
 selecting "*Color image*" from the *Select the image type* dropdown. If
 your classifier expects grayscale images, use **NamesAndTypes** to load
 images as "*Grayscale image*".
+
+Add more documentation.
 """
 
 ILASTIK_DOCKER = "biocontainers/ilastik:1.4.0_cv2"
@@ -92,7 +63,7 @@ ILASTIK_DOCKER = "biocontainers/ilastik:1.4.0_cv2"
 class Runilastik(cellprofiler_core.module.ImageProcessing):
     module_name = "Runilastik"
 
-    variable_revision_number = 1  #did not understand what this means 
+    variable_revision_number = 1  
 
     doi = {
         "Please cite the following when using Runilastik:": "https://doi.org/10.1038/s41592-019-0582-9",
@@ -194,23 +165,27 @@ Select the project type which matches the project file specified by
             os.makedirs(temp_img_dir, exist_ok=True)
 
             temp_img_path = os.path.join(temp_img_dir, unique_name+".tiff")
-            if self.mode.value == "custom":
-                model_file = self.model_file_name.value
-                model_directory = self.model_directory.get_absolute_path()
-                model_path = os.path.join(model_directory, model_file)
-                temp_model_dir = os.path.join(temp_dir, "model")
+            
+            model_file = self.project_file.value
+            model_directory = self.project_file.get_absolute_path()
+            model_path = os.path.join(model_directory, model_file)
+            temp_model_dir = os.path.join(temp_dir, "model")
 
-                os.makedirs(temp_model_dir, exist_ok=True)
-                # Copy the model
-                shutil.copy(model_path, os.path.join(temp_model_dir, model_file))
+            os.makedirs(temp_model_dir, exist_ok=True)
+            # Copy the model
+            shutil.copy(model_path, os.path.join(temp_model_dir, model_file))
 
             # Save the image to the Docker mounted directory
             skimage.io.imsave(temp_img_path, x_data)
 
             cmd = f"""
             {docker_path} run --rm -v {ILASTIK_DOCKER} /opt/ilastik-1.4.0-Linux/run_ilastik.sh {temp_dir}:/data
-            {'--project'+temp_model_dir+model_file}
+            {'--project'+temp_model_dir+model_file} # {temp_model_dir}
+            {"--headless"}
+            {"--output_format", "hdf5"}
             """
+
+        if self.docker_or_local.value == "Local":
 
             cmd = [
             self.executable.value,

--- a/active_plugins/Runilastik_test.py
+++ b/active_plugins/Runilastik_test.py
@@ -5,9 +5,7 @@
 #################################
 
 import os
-import skimage
 import subprocess
-import uuid
 import shutil
 import logging
 import sys
@@ -201,8 +199,6 @@ Select the project type which matches the project file specified by
         if self.project_type.value in ["Pixel Classification"]:
             cmd += ["--export_source", "Probabilities"]
         elif self.project_type.value in ["Autocontext (2-stage)"]:
-            x_data = skimage.img_as_ubyte(x_data)  # ilastik requires UINT8. Might be relaxed in future.
-
             cmd += ["--export_source", "probabilities stage 2"]
             #cmd += ["--export_source", "probabilities all stages"]
 
@@ -238,4 +234,12 @@ Select the project type which matches the project file specified by
             os.unlink(fin.name)
 
             os.unlink(fout.name)
+
+            # Delete the temporary files
+            try:
+                shutil.rmtree(temp_dir)
+            except:
+                LOGGER.error("Unable to delete temporary directory, files may be in use by another program.")
+                LOGGER.error("Temp folder is subfolder {tempdir} in your Default Output Folder.\nYou may need to remove it manually.")
+
             

--- a/active_plugins/Runilastik_test.py
+++ b/active_plugins/Runilastik_test.py
@@ -1,0 +1,275 @@
+#################################
+#
+# Imports from useful Python libraries
+#
+#################################
+
+import numpy
+import os
+import skimage
+import subprocess
+import uuid
+import shutil
+import logging
+import sys
+import h5py 
+import tempfile
+
+
+#################################
+#
+# Imports from CellProfiler
+#
+##################################
+
+from cellprofiler_core.image import Image
+from cellprofiler_core.module import Module
+from cellprofiler_core.setting.choice import Choice
+from cellprofiler_core.preferences import get_default_output_directory
+from cellprofiler_core.setting.text import (
+    Directory,
+    Filename,
+    Pathname,
+)
+
+ilastik_link = "https://doi.org/10.1038/s41592-019-0582-9"
+LOGGER = logging.getLogger(__name__)
+
+
+__doc__ = """\
+Runilastik
+=======
+
+Use an ilastik pixel classifier to generate a probability image. Each
+channel represents the probability of the pixels in the image belong to
+a particular class. Use **ColorToGray** to separate channels for further
+processing. For example, use **IdentifyPrimaryObjects** on a
+(single-channel) probability map to generate a segmentation. The order
+of the channels in **ColorToGray** is the same as the order of the
+labels within the ilastik project.
+
+CellProfiler automatically scales grayscale and color images to the
+[0.0, 1.0] range on load. Your ilastik classifier should be trained on
+images with the same scale as the prediction images. You can ensure
+consistent scales by:
+
+-  using **ImageMath** to convert the images loaded by CellProfiler back
+   to their original scale. Use these settings to rescale an image:
+
+   -  **Operation**: *None*
+   -  **Multiply the first image by**: *RESCALE_VALUE*
+   -  **Set values greater than 1 equal to 1?**: *No*
+
+   where *RESCALE_VALUE* is determined by your image data and the value
+   of *Set intensity range from* in **NamesAndTypes**. For example, the
+   *RESCALE_VALUE* for 32-bit images rescaled by "*Image bit-depth*" is
+   65535 (the maximum value allowed by this data type). Please refer to
+   the help for the setting *Set intensity range from* in
+   **NamesAndTypes** for more information.
+
+   This option is best when your training and prediction images do not
+   require any preprocessing by CellProfiler.
+
+-  preprocessing any training images with CellProfiler (e.g.,
+   **RescaleIntensity**) and applying the same pre-processing steps to
+   your analysis pipeline. You can use **SaveImages** to export training
+   images as 32-bit TIFFs.
+
+   This option requires two CellProfiler pipelines, but is effective
+   when your training and prediction images require preprocessing by
+   CellProfiler.
+
+Additionally, please ensure CellProfiler is configured to load images in
+the same format as ilastik. For example, if your ilastik classifier is
+trained on RGB images, use **NamesAndTypes** to load images as RGB by
+selecting "*Color image*" from the *Select the image type* dropdown. If
+your classifier expects grayscale images, use **NamesAndTypes** to load
+images as "*Grayscale image*".
+"""
+
+ILASTIK_DOCKER = "biocontainers/ilastik:1.4.0_cv2"
+
+class Runilastik(cellprofiler_core.module.ImageProcessing):
+    module_name = "Runilastik"
+
+    variable_revision_number = 1  #did not understand what this means 
+
+    doi = {
+        "Please cite the following when using Runilastik:": "https://doi.org/10.1038/s41592-019-0582-9",
+    }
+
+    def create_settings(self):
+        super(Runilastik, self).create_settings()
+
+        self.docker_or_local = Choice(
+            text="Run ilastik in docker or local environment",
+            choices=["Docker", "Local"],
+            value="Docker",
+            doc="""\
+If Docker is selected, ensure that Docker Desktop is open and running on your
+computer. On first run of the Runilastik plugin, the Docker container will be
+downloaded. However, this slow downloading process will only have to happen
+once.
+
+If Local is selected, the local install of ilastik will be used.
+""",
+        )
+
+        self.executable = Pathname(
+            "Executable",
+            doc="ilastik command line executable name, or location if it is not on your path."
+        )
+
+        self.project_file = Pathname(
+            "Project file",
+            doc="Path to the project file (\*.ilp)."
+        )
+
+        self.project_type = Choice(
+            "Select the project type",
+            [
+                "Pixel Classification",
+                "Autocontext (2-stage)"
+            ],
+            "Pixel Classification",
+            doc="""\
+Select the project type which matches the project file specified by
+*Project file*. CellProfiler supports two types of ilastik projects:
+
+-  *Pixel Classification*: Classify the pixels of an image given user
+   annotations. `Read more`_.
+
+-  *Autocontext (2-stage)*: Perform pixel classification in multiple
+   stages, sharing predictions between stages to improve results. `Read
+   more <http://ilastik.org/documentation/autocontext/autocontext>`__.
+
+.. _Read more: http://ilastik.org/documentation/pixelclassification/pixelclassification
+"""
+        )
+
+    def settings(self):
+        return [
+            self.x_name,
+            self.y_name,
+            self.docker_or_local,
+            self.executable,
+            self.project_file,
+            self.project_type,
+        ]
+    def visible_settings(self):
+        vis_settings = [self.docker_or_local]
+
+        if self.docker_or_python.value == "Local":
+            vis_settings += [self.executable]
+
+        vis_settings += [self.x_name, self.y_name, self.project_file, self.project_type]
+        
+        return vis_settings
+    
+    def run(self, workspace):
+        image = workspace.image_set.get_image(self.x_name.value)
+
+        x_data = image.pixel_data
+        x_data = x_data*image.scale
+
+        fin = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
+
+        fout = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
+
+        if self.executable.value[-4:] == ".app":
+            executable = os.path.join(self.executable.value, "Contents/MacOS/ilastik")
+        else:
+            executable = self.executable.value
+
+        if self.docker_or_local.value == "Docker":
+            # Define how to call docker
+            docker_path = "docker" if sys.platform.lower().startswith("win") else "/usr/local/bin/docker"
+            # Create a UUID for this run
+            unique_name = str(uuid.uuid4())
+            # Directory that will be used to pass images to the docker container
+            temp_dir = os.path.join(get_default_output_directory(), ".cellprofiler_temp", unique_name)
+            temp_img_dir = os.path.join(temp_dir, "img")
+            
+            os.makedirs(temp_dir, exist_ok=True)
+            os.makedirs(temp_img_dir, exist_ok=True)
+
+            temp_img_path = os.path.join(temp_img_dir, unique_name+".tiff")
+            if self.mode.value == "custom":
+                model_file = self.model_file_name.value
+                model_directory = self.model_directory.get_absolute_path()
+                model_path = os.path.join(model_directory, model_file)
+                temp_model_dir = os.path.join(temp_dir, "model")
+
+                os.makedirs(temp_model_dir, exist_ok=True)
+                # Copy the model
+                shutil.copy(model_path, os.path.join(temp_model_dir, model_file))
+
+            # Save the image to the Docker mounted directory
+            skimage.io.imsave(temp_img_path, x_data)
+
+            cmd = f"""
+            {docker_path} run --rm -v {ILASTIK_DOCKER} /opt/ilastik-1.4.0-Linux/run_ilastik.sh {temp_dir}:/data
+            {'--project'+temp_model_dir+model_file}
+            """
+
+            cmd = [
+            self.executable.value,
+            "--headless",
+            "--project", self.project_file.value,
+            "--output_format", "hdf5"
+        ]
+
+        if self.project_type.value in ["Pixel Classification"]:
+            cmd += ["--export_source", "Probabilities"]
+        elif self.project_type.value in ["Autocontext (2-stage)"]:
+            x_data = skimage.img_as_ubyte(x_data)  # ilastik requires UINT8. Might be relaxed in future.
+
+            cmd += ["--export_source", "probabilities stage 2"]
+            #cmd += ["--export_source", "probabilities all stages"]
+
+        cmd += [
+            "--output_filename_format", fout.name,
+            fin.name
+        ]
+
+        try:
+            with h5py.File(fin.name, "w") as f:
+                shape = x_data.shape
+
+                if x_data.ndim == 2:
+                  # ilastik appears to add a channel dimension
+                  # even if the image is grayscale
+                  shape += (1,)
+                
+                f.create_dataset("data", shape, data=x_data)
+
+            fin.close()
+
+            fout.close()
+
+            subprocess.check_call(cmd)
+
+            with h5py.File(fout.name, "r") as f:
+                y_data = f["exported_data"].value
+
+            y = cellprofiler_core.image.Image(y_data)
+
+            workspace.image_set.add(self.y_name.value, y)
+
+            if self.show_window:
+                workspace.display_data.x_data = x_data
+
+                workspace.display_data.y_data = y_data
+
+                workspace.display_data.dimensions = image.dimensions
+        except subprocess.CalledProcessError as cpe:
+            logger.error("Command {} exited with status {}".format(cpe.output, cpe.returncode), cpe)
+
+            raise cpe
+        except IOError as ioe:
+            raise ioe
+        finally:
+            os.unlink(fin.name)
+
+            os.unlink(fout.name)
+            

--- a/active_plugins/runilastik.py
+++ b/active_plugins/runilastik.py
@@ -20,7 +20,7 @@ import tempfile
 ##################################
 
 from cellprofiler_core.image import Image
-from cellprofiler_core.module.image_processing import ImageProcessing
+from cellprofiler_core.module import ImageProcessing
 from cellprofiler_core.setting.choice import Choice
 from cellprofiler_core.preferences import get_default_output_directory
 from cellprofiler_core.setting.text import (
@@ -58,7 +58,7 @@ Add more documentation.
 ILASTIK_DOCKER = "biocontainers/ilastik:1.4.0_cv2"
 
 class Runilastik(ImageProcessing):
-    module_name = "Runilastik"
+    module_name = "Rceunilastik"
 
     variable_revision_number = 1  
 
@@ -173,8 +173,8 @@ Select the project type which matches the project file specified by
             docker_path = "docker" if sys.platform.lower().startswith("win") else "/usr/local/bin/docker"
                        
             model_file = self.project_file.value
-            model_directory = self.project_file.get_absolute_path()
-
+            model_directory = os.path.dirname(os.path.abspath(model_file)) 
+            
             cmd = [f"{docker_path}", "run", "--rm", "-v", f"{temp_dir}:/data",
             "-v", f"{model_directory}:/model",
             f"{ILASTIK_DOCKER}", "/opt/ilastik-1.4.0-Linux/run_ilastik.sh", "--headless",

--- a/active_plugins/runilastik.py
+++ b/active_plugins/runilastik.py
@@ -58,7 +58,7 @@ Add more documentation.
 ILASTIK_DOCKER = "biocontainers/ilastik:1.4.0_cv2"
 
 class Runilastik(ImageProcessing):
-    module_name = "Rceunilastik"
+    module_name = "Runilastik"
 
     variable_revision_number = 1  
 
@@ -174,7 +174,7 @@ Select the project type which matches the project file specified by
                        
             model_file = self.project_file.value
             model_directory = os.path.dirname(os.path.abspath(model_file)) 
-            
+
             cmd = [f"{docker_path}", "run", "--rm", "-v", f"{temp_dir}:/data",
             "-v", f"{model_directory}:/model",
             f"{ILASTIK_DOCKER}", "/opt/ilastik-1.4.0-Linux/run_ilastik.sh", "--headless",


### PR DESCRIPTION
We were hoping the `Predict` module would actually be able to work with Windows in analysis mode, but alas it seems still very hard - it seems to not be a matter of how CellProfiler CALLS ilastik, but how ilastik is interacting with the threading model. I still haven't given up hope that it's fixable, I think it might be that all we need to do is to rather than try to keep it in the same thread, use Popen to give it its own - but for now, that's causing weirdness with the tempfiles. It might be not only solvable but fast to solve, just haven't taken the time to dig in.

In the meantime, Suganya was working on this Dockerized version. I can confirm it works in local and Docker mode on Mac (and it does contain all the improvements in #225). On a Windows VM, I can't test the Dockerized version, because you can't install Docker Desktop on a Windows VM (apparently AWS blocks doing virtualization turtles all the way down). On the VM, though, the local version works in test mode, and (as expected) not in analysis mode, on both CellProfiler running from source and the latest 4.2.6 build. Suganya though is getting weird errors on her PC, which could be her-PC specific or not. Will need to get hands-on to hers or another physical Windows machine to check, but wanted to mark the place we were at. 