### PR TITLE
Cellpose version below 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
                 ]
 
     cellpose_deps = [
-        "cellpose>=1.0.2"
+        "cellpose<3.0"
     ]
 
     omnipose_deps = [

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
                 ]
 
     cellpose_deps = [
-        "cellpose<3.0"
+        "cellpose>=1.0.2,<3.0"
     ]
 
     omnipose_deps = [


### PR DESCRIPTION
The latest version of cellpose (cellpose 3) results in an error which is rectified by downgrading to the older versions. 