### PR TITLE
updated runcellpose.py

### DIFF
--- a/active_plugins/runcellpose.py
+++ b/active_plugins/runcellpose.py
@@ -83,12 +83,6 @@ YES          YES          NO
 
 """
 
-"""
-Normalize images
-"""
-
-
-
 "Select Cellpose Docker Image"
 CELLPOSE_DOCKER_NO_PRETRAINED = "cellprofiler/runcellpose_no_pretrained:0.1"
 CELLPOSE_DOCKER_IMAGE_WITH_PRETRAINED = "cellprofiler/runcellpose_with_pretrained:0.1"

--- a/active_plugins/runcellpose.py
+++ b/active_plugins/runcellpose.py
@@ -83,9 +83,17 @@ YES          YES          NO
 
 """
 
+"""
+Normalize images
+"""
+
+
+
+"Select Cellpose Docker Image"
 CELLPOSE_DOCKER_NO_PRETRAINED = "cellprofiler/runcellpose_no_pretrained:0.1"
 CELLPOSE_DOCKER_IMAGE_WITH_PRETRAINED = "cellprofiler/runcellpose_with_pretrained:0.1"
 
+"Detection mode"
 MODEL_NAMES = ['cyto','nuclei','tissuenet','livecell', 'cyto2', 'general',
                 'CP', 'CPx', 'TN1', 'TN2', 'TN3', 'LC1', 'LC2', 'LC3', 'LC4', 'custom']
 
@@ -95,7 +103,7 @@ class RunCellpose(ImageSegmentation):
 
     module_name = "RunCellpose"
 
-    variable_revision_number = 4
+    variable_revision_number = 5
 
     doi = {
         "Please cite the following when using RunCellPose:": "https://doi.org/10.1038/s41592-020-01018-x",
@@ -104,6 +112,16 @@ class RunCellpose(ImageSegmentation):
 
     def create_settings(self):
         super(RunCellpose, self).create_settings()
+
+        self.rescale = Binary(
+            text="Rescale images before running Cellpose",
+            value=True,
+            doc="""\
+Reminds the user that the  normalization step will be performed to ensure suimilar segmentation behaviour inthe RunCellpose
+modul and the Cellpose app.
+"""
+        )
+
 
         self.docker_or_python = Choice(
             text="Run CellPose in docker or local python environment",
@@ -340,6 +358,7 @@ The default is set to "Yes".
     def settings(self):
         return [
             self.x_name,
+            self.rescale,
             self.docker_or_python,
             self.docker_image,
             self.expected_diameter,
@@ -365,7 +384,8 @@ The default is set to "Yes".
         ]
 
     def visible_settings(self):
-        vis_settings = [self.docker_or_python]
+        vis_settings = [self.rescale, self.docker_or_python]
+
 
         if self.docker_or_python.value == "Docker":
             vis_settings += [self.docker_image]
@@ -440,6 +460,13 @@ The default is set to "Yes".
         x = images.get_image(x_name)
         dimensions = x.dimensions
         x_data = x.pixel_data
+
+        if self.rescale.value:
+            rescale_x = x_data.copy()
+            x01 = numpy.percentile(rescale_x, 1)
+            x99 = numpy.percentile(rescale_x, 99)
+            x_data = numpy.clip((rescale_x - x01) / (x99 - x01), a_min=0, a_max=1)
+
         anisotropy = 0.0
         if self.do_3D.value:
             anisotropy = x.spacing[0] / x.spacing[1]
@@ -699,4 +726,9 @@ The default is set to "Yes".
         if variable_revision_number == 3:
             setting_values = [setting_values[0]] + ["Python",CELLPOSE_DOCKER_IMAGE_WITH_PRETRAINED] + setting_values[1:]
             variable_revision_number = 4
+        if variable_revision_number == 4:
+            setting_values = [setting_values[0]] + ['No'] + [setting_values[1:]]
+            variable_revision_number = 5
         return setting_values, variable_revision_number
+    
+


### PR DESCRIPTION
### **Problem**
Cellpose v2 while reading images converts to float and normalizes the image by setting the first percentile to 0, the 99th percentile to 1, and scaling the image to those values (while clipping the top and the bottom of the distribution).
As this operation is not included when images are loaded in CellProfiler, this step may lead to a mismatch in segmentation when using the Cellpose app vs using the RunCellpose plugin within CellProfiler.

### **Update**
To solve this issue, a setting has been added to allow people to rescale their images before segmenting it through RunCellpose. The default option for this is "yes" and upgrade settings has been set to "no".