### PR TITLE
Check custom model solved with from cellpose import models #237

### DIFF
--- a/active_plugins/runcellpose.py
+++ b/active_plugins/runcellpose.py
@@ -441,6 +441,7 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
 
     def validate_module(self, pipeline):
         """If using custom model, validate the model file opens and works"""
+        from cellpose import models
         if self.mode.value == "custom":
             model_file = self.model_file_name.value
             model_directory = self.model_directory.get_absolute_path()


### PR DESCRIPTION
As described in issue #237, when using RunCellpose, the pipeline check accused that a custom model failed to load but the pipeline ran anyway. 

Importing the models from cellpose inside `validate_module` function solved the issue on my end since it had not been imported before.


