### PR TITLE
disable automatic testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,12 @@
 name: Basic plugin testing
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, review_requested]
+  #push:
+    #branches:
+      #- master
+  #pull_request:
+    #types: [opened, reopened, synchronize, ready_for_review, review_requested]
+  workflow_dispatch:
 
 jobs:
   build_cellprofiler:

--- a/.github/workflows/test_cellpose.yml
+++ b/.github/workflows/test_cellpose.yml
@@ -1,11 +1,12 @@
 name: CellProfiler-Cellpose
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, review_requested]
+  #push:
+    #branches:
+      #- master
+  #pull_request:
+    #types: [opened, reopened, synchronize, ready_for_review, review_requested]
+  workflow_dispatch:
 
 jobs:
   build_cellprofiler:

--- a/.github/workflows/test_stardist.yml
+++ b/.github/workflows/test_stardist.yml
@@ -1,11 +1,12 @@
 name: CellProfiler-Stardist
 
 on:
-    push:
-      branches:
-        - master
-    pull_request:
-      types: [opened, reopened, synchronize, ready_for_review, review_requested]
+  #push:
+    #branches:
+      #- master
+  #pull_request:
+    #types: [opened, reopened, synchronize, ready_for_review, review_requested]
+  workflow_dispatch:
 
 jobs:
   build_cellprofiler:


### PR DESCRIPTION
Need updated CellProfiler install instructions to get tests running.
As Python3.8 has been deprecated, this may take some troubleshooting so I am disabling automatic testing and will keep issue open in repo noting that it needs to be fixed.