### PR TITLE
Fix to allow to run on 3d images

### DIFF
--- a/active_plugins/runcellpose.py
+++ b/active_plugins/runcellpose.py
@@ -872,6 +872,13 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
 
             elif self.cellpose_version.value == 'v4':
                 assert int(self.cellpose_ver[0])==4, "Cellpose version selected in RunCellpose module doesn't match version in Python"
+                
+                # For processing 3D data, model requires to specify which axis defines z dimension
+                if x.volumetric:
+                    z_axis=0
+                else:
+                    z_axis=None
+
                 if self.mode.value == 'custom':
                     model_file, model_directory, model_path  = get_custom_model_vars(self)
                 model_params = (self.mode.value, self.use_gpu.value)
@@ -892,6 +899,7 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
                     try:
                         y_data, flows, *_ = self.current_model.eval(
                             x_data,
+                            z_axis=z_axis,                            
                             diameter=diam,
                             do_3D=self.do_3D.value,
                             anisotropy=anisotropy,
@@ -915,6 +923,8 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
                     try:
                         y_data, flows, *_ = self.current_model.eval(
                             x_data,
+                            # channel_axis=,
+                            z_axis=z_axis,
                             do_3D=self.do_3D.value,
                             anisotropy=anisotropy,
                             flow_threshold=self.flow_threshold.value,

--- a/active_plugins/runcellpose.py
+++ b/active_plugins/runcellpose.py
@@ -1133,9 +1133,17 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
             y=0,
         )
         
-        cplabels = [
-                dict(name=self.y_name.value, labels=[workspace.display_data.primary_labels]),
-            ]
+        # Only display labels when processing 2D data
+        x_name = self.x_name.value
+        images = workspace.image_set
+        x = images.get_image(x_name)
+
+        if x.volumetric:
+            cplabels=None
+        else:
+            cplabels = [
+                    dict(name=self.y_name.value, labels=[workspace.display_data.primary_labels]),
+                ]
 
         title = "%s outlines" % self.y_name.value
         figure.subplot_imshow_grayscale(

--- a/active_plugins/runcellpose.py
+++ b/active_plugins/runcellpose.py
@@ -872,7 +872,7 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
 
             elif self.cellpose_version.value == 'v4':
                 assert int(self.cellpose_ver[0])==4, "Cellpose version selected in RunCellpose module doesn't match version in Python"
-                
+                LOGGER.info(f"Loading new model: {self.mode.value}")
                 # For processing 3D data, model requires to specify which axis defines z dimension
                 if x.volumetric:
                     z_axis=0
@@ -881,10 +881,10 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
 
                 if self.mode.value == 'custom':
                     model_file, model_directory, model_path  = get_custom_model_vars(self)
-                model_params = (self.mode.value, self.use_gpu.value)
-                LOGGER.info(f"Loading new model: {self.mode.value}")
-                self.current_model = models.CellposeModel(gpu=self.use_gpu.value)
-                self.current_model_params = model_params
+                    self.current_model = models.CellposeModel(
+                        pretrained_model=model_path, gpu=self.use_gpu.value)
+                else:
+                    self.current_model = models.CellposeModel(gpu=self.use_gpu.value)
 
                 if self.use_gpu.value:
                     try:

--- a/active_plugins/runcellpose.py
+++ b/active_plugins/runcellpose.py
@@ -1049,10 +1049,11 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
                 prob_map = numpy.clip((rescale_prob_map - prob_map01) / (prob_map99 - prob_map01), a_min=0, a_max=1)
             # Flows come out sized relative to CellPose's inbuilt model size.
             # We need to slightly resize to match the original image.
-            size_corrected = skimage.transform.resize(prob_map, y_data.shape)
+            size_corrected = skimage.transform.resize(prob_map, x_data.shape)
             prob_image = Image(
                 size_corrected,
                 parent_image=x.parent_image,
+                mask=x.mask,
                 convert=False,
                 dimensions=len(size_corrected.shape),
             )

--- a/active_plugins/runcellpose.py
+++ b/active_plugins/runcellpose.py
@@ -1112,7 +1112,9 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
         else:
             layout = (2, 2)
 
-        figure.set_subplots(subplots=layout)
+        dimensions = workspace.display_data.dimensions
+
+        figure.set_subplots(subplots=layout, dimensions=dimensions)
         
         title = "Input image, cycle #%d" % (workspace.measurements.image_number,)
         figure.subplot_imshow(
@@ -1137,7 +1139,12 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
 
         title = "%s outlines" % self.y_name.value
         figure.subplot_imshow_grayscale(
-            0, 1, workspace.display_data.x_data, title, cplabels=cplabels, sharexy=figure.subplot(0, 0),
+            x=0, 
+            y=1, 
+            image=workspace.display_data.x_data, 
+            title=title, 
+            cplabels=cplabels, 
+            sharexy=figure.subplot(0, 0),
         )
 
         figure.subplot_table(

--- a/active_plugins/runcellpose.py
+++ b/active_plugins/runcellpose.py
@@ -923,7 +923,8 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
                     try:
                         y_data, flows, *_ = self.current_model.eval(
                             x_data,
-                            # channel_axis=,
+                            # channel_axis=None,
+                            # channels=channels,
                             z_axis=z_axis,
                             do_3D=self.do_3D.value,
                             anisotropy=anisotropy,
@@ -944,8 +945,8 @@ Activate to rescale probability map to 0-255 (which matches the scale used when 
                             self.current_model = None
                             self.current_model_params = None
 
-            if self.remove_edge_masks:
-                y_data = utils.remove_edge_masks(y_data)
+                if self.remove_edge_masks:
+                    y_data = utils.remove_edge_masks(y_data)
 
         else:
             if self.docker_or_python.value == "Docker":


### PR DESCRIPTION
- Adds a new parameter to be passed to the Cellpose call when running on volumetric images: `z_axiz'
- Allows volumetric display 
- Avoids showind outlines when doing volumetric display to escape shape mismatch error (third panel still shows the raw image but without outlines)