### PR TITLE
Bugfixes, mininum measurment value for non-one-hot

### DIFF
--- a/active_plugins/callbarcodes.py
+++ b/active_plugins/callbarcodes.py
@@ -673,11 +673,17 @@ No other channel formats are available at this time, though you are free to open
                     )
 
                 if self.show_window:
-                    workspace.display_data.col_labels = (
-                        "Image Mean Score",
-                        "Image Mean Quality Score",
-                    )
-                    workspace.display_data.statistics = [imagemeanscore, imagemeanquality]
+                    if self.n_colors.value == ENCODING_TYPES[0]:
+                        workspace.display_data.col_labels = (
+                            "Image Mean Score",
+                            "Image Mean Quality Score",
+                        )
+                        workspace.display_data.statistics = [imagemeanscore, imagemeanquality]
+                    else:
+                        workspace.display_data.col_labels = (
+                            "Image Mean Score"
+                        )
+                        workspace.display_data.statistics = [imagemeanscore]
             
             else:
                 if self.show_window:

--- a/active_plugins/callbarcodes.py
+++ b/active_plugins/callbarcodes.py
@@ -528,140 +528,178 @@ No other channel formats are available at this time, though you are free to open
             self.input_object_name.value
         )
 
+        objectcount = measurements.get_current_measurement('Image',f'Count_{self.input_object_name.value}')
+
         if self.n_colors.value == ENCODING_TYPES[0]:
             measurements_for_calls = self.getallonehotbarcodemeasurements(
                 listofmeasurements, self.ncycles.value, self.cycle1measure.value
             )
             first_cycle_measures = list(measurements_for_calls[1].keys())
 
-            # Use a known barcode intensity measurement to determine object count
-            objectcount = len(
-                measurements.get_current_measurement(
-                    self.input_object_name.value, first_cycle_measures[0]
-                )
-            )
-            calledbarcodes, quality_scores = self.callonehotbarcode(
-                measurements_for_calls,
-                measurements,
-                self.input_object_name.value,
-                self.ncycles.value,
-                objectcount,
-            )
+            if objectcount >=1:
 
-            workspace.measurements.add_measurement(
-                self.input_object_name.value,
-                "_".join([C_CALL_BARCODES, "MeanQualityScore"]),
-                quality_scores,
-            )
-
-            imagemeanquality = numpy.mean(quality_scores)
-
-            workspace.measurements.add_measurement(
-                "Image", "_".join([C_CALL_BARCODES, "MeanQualityScore"]), imagemeanquality
-            )
-        else:
-            calledbarcodes = self.calloneexpISSbarcode(
-                self.base_measurements,
-                measurements,
-                self.input_object_name.value,
-                self.ncycles.value)
-
-        workspace.measurements.add_measurement(
-            self.input_object_name.value,
-            "_".join([C_CALL_BARCODES, "BarcodeCalled"]),
-            calledbarcodes,
-        )
-        if self.do_library_match.value:
-            barcodes = self.barcodeset(
-                self.metadata_field_barcode.value, self.metadata_field_tag.value
-            )
-
-            cropped_barcode_dict = {
-                y[: self.ncycles.value]: y for y in list(barcodes.keys())
-            }
-
-            scorelist = []
-            matchedbarcode = []
-            matchedbarcodecode = []
-            matchedbarcodeid = []
-            if self.wants_call_image or self.wants_score_image:
-                objects = workspace.object_set.get_objects(self.input_object_name.value)
-                labels = objects.segmented
-                pixel_data_call = objects.segmented
-                pixel_data_score = objects.segmented
-            count = 1
-            for eachbarcode in calledbarcodes:
-                eachscore, eachmatch = self.queryall(cropped_barcode_dict, eachbarcode)
-                scorelist.append(eachscore)
-                matchedbarcode.append(eachmatch)
-                m_id, m_code = barcodes[eachmatch]
-                matchedbarcodeid.append(m_id)
-                matchedbarcodecode.append(m_code)
-                if self.wants_call_image:
-                    pixel_data_call = numpy.where(
-                        labels == count, barcodes[eachmatch][0], pixel_data_call
-                    )
-                if self.wants_score_image:
-                    pixel_data_score = numpy.where(
-                        labels == count, 65535 * eachscore, pixel_data_score
-                    )
-                count += 1
-
-            imagemeanscore = numpy.mean(scorelist)
-
-            workspace.measurements.add_measurement(
-                "Image", "_".join([C_CALL_BARCODES, "MeanBarcodeScore"]), imagemeanscore
-            )
-
-            workspace.measurements.add_measurement(
-                self.input_object_name.value,
-                "_".join([C_CALL_BARCODES, "MatchedTo_Barcode"]),
-                matchedbarcode,
-            )
-            workspace.measurements.add_measurement(
-                self.input_object_name.value,
-                "_".join([C_CALL_BARCODES, "MatchedTo_ID"]),
-                matchedbarcodeid,
-            )
-            workspace.measurements.add_measurement(
-                self.input_object_name.value,
-                "_".join([C_CALL_BARCODES, "MatchedTo_GeneCode"]),
-                matchedbarcodecode,
-            )
-            workspace.measurements.add_measurement(
-                self.input_object_name.value,
-                "_".join([C_CALL_BARCODES, "MatchedTo_Score"]),
-                scorelist,
-            )
-            if self.wants_call_image:
-                workspace.image_set.add(
-                    self.outimage_calls_name.value,
-                    cellprofiler_core.image.Image(
-                        pixel_data_call.astype("uint16"), convert=False
-                    ),
-                )
-            if self.wants_score_image:
-                workspace.image_set.add(
-                    self.outimage_score_name.value,
-                    cellprofiler_core.image.Image(
-                        pixel_data_score.astype("uint16"), convert=False
-                    ),
+                calledbarcodes, quality_scores = self.callonehotbarcode(
+                    measurements_for_calls,
+                    measurements,
+                    self.input_object_name.value,
+                    self.ncycles.value,
+                    objectcount,
                 )
 
-            if self.show_window:
-                workspace.display_data.col_labels = (
-                    "Image Mean Score",
-                    "Image Mean Quality Score",
+                workspace.measurements.add_measurement(
+                    self.input_object_name.value,
+                    "_".join([C_CALL_BARCODES, "MeanQualityScore"]),
+                    quality_scores,
                 )
-                workspace.display_data.statistics = [imagemeanscore, imagemeanquality]
+
+                imagemeanquality = numpy.mean(quality_scores)
+
+                workspace.measurements.add_measurement(
+                    "Image", "_".join([C_CALL_BARCODES, "MeanQualityScore"]), imagemeanquality
+                )
+            
+            else:
+                workspace.measurements.add_measurement(
+                    "Image", "_".join([C_CALL_BARCODES, "MeanQualityScore"]), 0
+                )
         
         else:
-            if self.show_window:
-                workspace.display_data.col_labels = (
-                    "Number barcodes",
-                    "Number of unique calls",
+            if objectcount >= 1:
+                calledbarcodes = self.calloneexpISSbarcode(
+                    self.base_measurements,
+                    measurements,
+                    self.input_object_name.value,
+                    self.ncycles.value)
+                
+        if objectcount >= 1:
+            workspace.measurements.add_measurement(
+                self.input_object_name.value,
+                "_".join([C_CALL_BARCODES, "BarcodeCalled"]),
+                calledbarcodes,
+            )
+
+            if self.do_library_match.value:
+                barcodes = self.barcodeset(
+                    self.metadata_field_barcode.value, self.metadata_field_tag.value
                 )
-                workspace.display_data.statistics = [len(calledbarcodes), len(list(set([calledbarcodes])))]
+
+                cropped_barcode_dict = {
+                    y[: self.ncycles.value]: y for y in list(barcodes.keys())
+                }
+
+                scorelist = []
+                matchedbarcode = []
+                matchedbarcodecode = []
+                matchedbarcodeid = []
+                if self.wants_call_image or self.wants_score_image:
+                    objects = workspace.object_set.get_objects(self.input_object_name.value)
+                    labels = objects.segmented
+                    pixel_data_call = objects.segmented
+                    pixel_data_score = objects.segmented
+                count = 1
+                for eachbarcode in calledbarcodes:
+                    eachscore, eachmatch = self.queryall(cropped_barcode_dict, eachbarcode)
+                    scorelist.append(eachscore)
+                    matchedbarcode.append(eachmatch)
+                    m_id, m_code = barcodes[eachmatch]
+                    matchedbarcodeid.append(m_id)
+                    matchedbarcodecode.append(m_code)
+                    if self.wants_call_image:
+                        pixel_data_call = numpy.where(
+                            labels == count, barcodes[eachmatch][0], pixel_data_call
+                        )
+                    if self.wants_score_image:
+                        pixel_data_score = numpy.where(
+                            labels == count, 65535 * eachscore, pixel_data_score
+                        )
+                    count += 1
+
+                imagemeanscore = numpy.mean(scorelist)
+
+                workspace.measurements.add_measurement(
+                    "Image", "_".join([C_CALL_BARCODES, "MeanBarcodeScore"]), imagemeanscore
+                )
+
+                workspace.measurements.add_measurement(
+                    self.input_object_name.value,
+                    "_".join([C_CALL_BARCODES, "MatchedTo_Barcode"]),
+                    matchedbarcode,
+                )
+                workspace.measurements.add_measurement(
+                    self.input_object_name.value,
+                    "_".join([C_CALL_BARCODES, "MatchedTo_ID"]),
+                    matchedbarcodeid,
+                )
+                workspace.measurements.add_measurement(
+                    self.input_object_name.value,
+                    "_".join([C_CALL_BARCODES, "MatchedTo_GeneCode"]),
+                    matchedbarcodecode,
+                )
+                workspace.measurements.add_measurement(
+                    self.input_object_name.value,
+                    "_".join([C_CALL_BARCODES, "MatchedTo_Score"]),
+                    scorelist,
+                )
+                if self.wants_call_image:
+                    workspace.image_set.add(
+                        self.outimage_calls_name.value,
+                        cellprofiler_core.image.Image(
+                            pixel_data_call.astype("uint16"), convert=False
+                        ),
+                    )
+                if self.wants_score_image:
+                    workspace.image_set.add(
+                        self.outimage_score_name.value,
+                        cellprofiler_core.image.Image(
+                            pixel_data_score.astype("uint16"), convert=False
+                        ),
+                    )
+
+                if self.show_window:
+                    workspace.display_data.col_labels = (
+                        "Image Mean Score",
+                        "Image Mean Quality Score",
+                    )
+                    workspace.display_data.statistics = [imagemeanscore, imagemeanquality]
+            
+            else:
+                if self.show_window:
+                    workspace.display_data.col_labels = (
+                        "Number barcodes",
+                        "Number of unique calls",
+                    )
+                    workspace.display_data.statistics = [len(calledbarcodes), len(list(set([calledbarcodes])))]
+        
+        else:
+            if self.do_library_match.value:
+                workspace.measurements.add_measurement(
+                    "Image", "_".join([C_CALL_BARCODES, "MeanBarcodeScore"]), 0
+                )
+                if self.wants_call_image or self.wants_score_image:
+                    objects = workspace.object_set.get_objects(self.input_object_name.value)
+                    labels = objects.segmented
+                    zeros = numpy.zeros_like(labels)
+                    if self.wants_call_image:
+                        workspace.image_set.add(
+                                self.outimage_calls_name.value,
+                                cellprofiler_core.image.Image(
+                                    zeros, convert=False
+                                ),
+                            )
+                    if self.wants_score_image:
+                        workspace.image_set.add(
+                            self.outimage_score_name.value,
+                            cellprofiler_core.image.Image(
+                                zeros, convert=False
+                            ),
+                        )
+
+            workspace.display_data.col_labels = (
+                "Number barcodes",
+                "Number of unique calls",
+            )
+            workspace.display_data.statistics = [0, 0]
+
 
     def display(self, workspace, figure):
         statistics = workspace.display_data.statistics

--- a/active_plugins/callbarcodes.py
+++ b/active_plugins/callbarcodes.py
@@ -707,6 +707,8 @@ No other channel formats are available at this time, though you are free to open
                                 zeros, convert=False
                             ),
                         )
+                
+                self.measurements_without_objects(workspace, self.input_object_name.value)
 
             if self.show_window:
                 workspace.display_data.statistics = [
@@ -863,6 +865,16 @@ No other channel formats are available at this time, though you are free to open
             scores = list(scoredict.keys())
             scores.sort(reverse=True)
             return scores[0], cropped_barcode_dict[scoredict[scores[0]]]
+        
+    def measurements_without_objects(self, workspace, object_name):
+        # Create column headers even if there were no objects in a set.
+        features_to_record = self.get_measurements(workspace.pipeline, object_name, C_CALL_BARCODES)
+        empty_measure = numpy.zeros((0,))
+        for feature_name in features_to_record:
+            workspace.add_measurement(
+            object_name, "%s_%s" % (C_CALL_BARCODES, feature_name), empty_measure
+        )
+           
 
     def get_measurement_columns(self, pipeline):
 

--- a/active_plugins/callbarcodes.py
+++ b/active_plugins/callbarcodes.py
@@ -99,13 +99,15 @@ BASE_BOOLEAN_LONG_DESCRIPTION = "Select *Yes* if this measurement is *inclusive*
 # The number of settings per metric
 METRIC_SETTING_COUNT = 3
 
-FIXED_SETTING_COUNT = 15
+FIXED_SETTING_COUNT = 16
+
+FIXED_SETTING_COUNT_BEFORE_NON_1HOT = 15
 
 class CallBarcodes(cellprofiler_core.module.Module):
 
     module_name = "CallBarcodes"
     category = "Data Tools"
-    variable_revision_number = 3
+    variable_revision_number = 4
 
     def create_settings(self):
         self.csv_directory = cellprofiler_core.setting.text.Directory(
@@ -148,6 +150,16 @@ Enter the number of cycles present in the data.
             text="Number of cycles",
             value=8,
         )
+
+        self.min_value = cellprofiler_core.setting.text.Float(
+            doc="""\
+Set the minimum measurement value required to be considered positive for a channel. Foci 
+with values >= this value for the chosen measurement will be called positive.
+""",
+            text="Minimum value to be considered positive in a channel",
+            value=1,
+        )
+
         self.cycle1measure = cellprofiler_core.setting.Measurement(
             "Select one of the measures from Cycle 1 to use for calling",
             self.input_object_name.get_value,
@@ -331,7 +343,7 @@ No other channel formats are available at this time, though you are free to open
         value_count = len(setting_values)
         assert (value_count - FIXED_SETTING_COUNT) % METRIC_SETTING_COUNT == 0
         bases_encountered = []
-        for x in range(FIXED_SETTING_COUNT,value_count,METRIC_SETTING_COUNT):
+        for x in range(FIXED_SETTING_COUNT_BEFORE_NON_1HOT,value_count,METRIC_SETTING_COUNT):
             if setting_values[x] not in bases_encountered:
                 #don't add an "extra" setting for the first one of each base, added in create_settings
                 bases_encountered.append(setting_values[x])
@@ -364,6 +376,9 @@ No other channel formats are available at this time, though you are free to open
                     measurement.measurement_name,
                     measurement.base_boolean,
                 ]
+        
+        result += [self.min_value]
+
         return result
 
     def visible_settings(self):
@@ -376,6 +391,7 @@ No other channel formats are available at this time, though you are free to open
             self.cycle1measure
             ]
         else:
+            result += [self.min_value]
             add_buttons = {"A":[self.add_button_a, self.divider_1], "C":[self.add_button_c, self.divider_2],
                            "G":[self.add_button_g, self.divider_3], "T":[self.add_button_t]}
             for base in self.base_measurements.keys():
@@ -569,7 +585,8 @@ No other channel formats are available at this time, though you are free to open
                     self.base_measurements,
                     measurements,
                     self.input_object_name.value,
-                    self.ncycles.value)
+                    self.ncycles.value,
+                    self.min_value.value)
                 
         if objectcount >= 1:
             workspace.measurements.add_measurement(
@@ -709,7 +726,7 @@ No other channel formats are available at this time, though you are free to open
         figure.subplot_table(0, 0, statistics)
 
     def calloneexpISSbarcode(self, calling_setting_dict, measurements, 
-                             object_name, ncycles):
+                             object_name, ncycles, min_value):
         def call_by_column(base_array):
             base_order = ['A','C','G','T']
             if sum(base_array) != 1:
@@ -742,10 +759,10 @@ No other channel formats are available at this time, though you are free to open
                 base = call_bool_dict[base_list[base_order]]
                 if True in base.keys():
                     for eachmeas in base[True]:
-                        this_base_array = this_base_array * (measurements.get_current_measurement(object_name,eachmeas[cycle]) > 0)
+                        this_base_array = this_base_array * (measurements.get_current_measurement(object_name,eachmeas[cycle]) >= min_value)
                 if False in base.keys():
                     for eachmeas in base[False]:
-                        this_base_array = this_base_array * ~(measurements.get_current_measurement(object_name,eachmeas[cycle]) > 0)
+                        this_base_array = this_base_array * ~(measurements.get_current_measurement(object_name,eachmeas[cycle]) >= min_value)
                 which_base_array[:,base_order] = this_base_array
             full_base_array = numpy.char.add(full_base_array,numpy.apply_along_axis(call_by_column,1,which_base_array)) 
         return list(full_base_array)
@@ -954,4 +971,7 @@ No other channel formats are available at this time, though you are free to open
         if variable_revision_number == 2:
             setting_values = setting_values[:14]+["Yes"]+setting_values[14:]
             variable_revision_number = 3
+        if variable_revision_number == 3:
+            setting_values = setting_values+[1]
+            variable_revision_number = 4
         return setting_values, variable_revision_number

--- a/active_plugins/callbarcodes.py
+++ b/active_plugins/callbarcodes.py
@@ -568,7 +568,7 @@ No other channel formats are available at this time, though you are free to open
                     quality_scores,
                 )
 
-                imagemeanquality = numpy.mean(quality_scores)
+                imagemeanquality = float(numpy.mean(quality_scores))
 
                 workspace.measurements.add_measurement(
                     "Image", "_".join([C_CALL_BARCODES, "MeanQualityScore"]), imagemeanquality
@@ -631,7 +631,7 @@ No other channel formats are available at this time, though you are free to open
                         )
                     count += 1
 
-                imagemeanscore = numpy.mean(scorelist)
+                imagemeanscore = float(numpy.mean(scorelist))
 
                 workspace.measurements.add_measurement(
                     "Image", "_".join([C_CALL_BARCODES, "MeanBarcodeScore"]), imagemeanscore
@@ -672,26 +672,17 @@ No other channel formats are available at this time, though you are free to open
                         ),
                     )
 
-                if self.show_window:
+            if self.show_window:
+                workspace.display_data.statistics = [
+                        ("Number barcodes", len(calledbarcodes)), 
+                        ("Number of unique calls",len(list(set(calledbarcodes))))
+                ]
+                if self.do_library_match:
+                    workspace.display_data.statistics += [("Image Mean Score",imagemeanscore)]
+                    
                     if self.n_colors.value == ENCODING_TYPES[0]:
-                        workspace.display_data.col_labels = (
-                            "Image Mean Score",
-                            "Image Mean Quality Score",
-                        )
-                        workspace.display_data.statistics = [imagemeanscore, imagemeanquality]
-                    else:
-                        workspace.display_data.col_labels = (
-                            "Image Mean Score"
-                        )
-                        workspace.display_data.statistics = [imagemeanscore]
-            
-            else:
-                if self.show_window:
-                    workspace.display_data.col_labels = (
-                        "Number barcodes",
-                        "Number of unique calls",
-                    )
-                    workspace.display_data.statistics = [len(calledbarcodes), len(list(set([calledbarcodes])))]
+                        workspace.display_data.statistics += [ ("Image Mean Quality Score",imagemeanquality)]
+
         
         else:
             if self.do_library_match.value:
@@ -717,11 +708,11 @@ No other channel formats are available at this time, though you are free to open
                             ),
                         )
 
-            workspace.display_data.col_labels = (
-                "Number barcodes",
-                "Number of unique calls",
-            )
-            workspace.display_data.statistics = [0, 0]
+            if self.show_window:
+                workspace.display_data.statistics = [
+                        ("Number barcodes", 0), 
+                        ("Number of unique calls",0)
+                ]
 
 
     def display(self, workspace, figure):


### PR DESCRIPTION
Fixes errors when no barcodes are found in non-one-hot calling, and using a more robust metric for one-hot calling to get the number of barcodes since previous metric was occasionally weird.

Also adds a settable minimum value for declaring a measurement "positive" for a particular channel. Previously, it was "zero" or "nonzero" - it would still in an ideal world be nice to have this SUPER customizable, but I think this is a good "split the difference", since I don't think we really want to live in a universe where the number of options for each channel is quasi-infinite.